### PR TITLE
An internal stubbing interface for Trebuchet

### DIFF
--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -54,6 +54,10 @@ class Trebuchet
     Feature.find(feature_name).dismantle
   end
 
+  def self.dismantle_stubs
+    Feature.dismantle_stubs
+  end
+
   def self.define_strategy(name, &block)
     Strategy::Custom.define(name, block)
   end
@@ -140,4 +144,5 @@ require 'trebuchet/strategy/multiple'
 require 'trebuchet/strategy/visitor_percent'
 require 'trebuchet/strategy/visitor_percent_deprecated'
 require 'trebuchet/strategy/hostname'
+require 'trebuchet/strategy/stub'
 require 'trebuchet/action_controller'

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -1,4 +1,8 @@
+require 'trebuchet/feature/stubbing'
+
 class Trebuchet::Feature
+  include Stubbing
+
   @@deprecated_strategies_enabled = true
 
   attr_accessor :name

--- a/lib/trebuchet/feature/stubbing.rb
+++ b/lib/trebuchet/feature/stubbing.rb
@@ -1,0 +1,31 @@
+class Trebuchet
+  class Feature
+    module Stubbing
+
+      def stub(state)
+        self.class.stubbed_features[name] = state
+      end
+
+      def stubbed?
+        !!self.class.stubbed_features[name]
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+
+        def dismantle_stubs
+          @stubbed_features = nil
+        end
+
+        def stubbed_features
+          @stubbed_features ||= {}
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/trebuchet/strategy.rb
+++ b/lib/trebuchet/strategy.rb
@@ -3,8 +3,13 @@ require 'digest/sha1'
 module Trebuchet::Strategy
 
   def self.for_feature(feature)
-    strategy_args = Trebuchet.backend.get_strategy(feature.name)
-    find(*strategy_args).tap {|s| s.feature = feature }
+    stub_state = Trebuchet::Feature.stubbed_features[feature.name]
+    if stub_state
+      Stub.new(stub_state)
+    else
+      strategy_args = Trebuchet.backend.get_strategy(feature.name)
+      find(*strategy_args).tap {|s| s.feature = feature }
+    end
   end
 
   def self.find(*args)
@@ -25,6 +30,8 @@ module Trebuchet::Strategy
     end
   end
 
+  # The stub strategy purposely left out of this list as it should be
+  # accessible via the testing interface only and not externally.
   def self.name_class_map
     [
       [:visitor_percent_deprecated, VisitorPercentDeprecated],

--- a/lib/trebuchet/strategy/stub.rb
+++ b/lib/trebuchet/strategy/stub.rb
@@ -1,0 +1,30 @@
+class Trebuchet
+  module Strategy
+
+    class Stub < Trebuchet::Strategy::Base
+      attr_reader :state
+
+      def initialize(state)
+        @state = state
+      end
+
+      def launch_at?(user, request = nil)
+        state == :launched
+      end
+
+      def needs_user?
+        false
+      end
+
+      def to_s
+        "stub (#{state}}"
+      end
+
+      def export
+        super state
+      end
+
+    end
+
+  end
+end

--- a/spec/stubbing_spec.rb
+++ b/spec/stubbing_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe Trebuchet::Feature::Stubbing do
+
+  before do
+    Trebuchet.dismantle_stubs
+  end
+
+  describe '#stub' do
+
+    it "should stub a feature as launched" do
+      Trebuchet.feature('test').stub(:launched)
+      should_launch('test', [0])
+    end
+
+    it "should stub a feature as not launched" do
+      Trebuchet.feature('test').stub(:not_launched)
+      should_not_launch('test', [0])
+    end
+
+    it "should employ the stub strategy for features stubbed launched" do
+      Trebuchet.feature('test').stub(:launched)
+      Trebuchet.feature('test').strategy.is_a?(Trebuchet::Strategy::Stub)
+    end
+
+    it "should employ the stub strategy for features stubbed not launched" do
+      Trebuchet.feature('test').stub(:not_launched)
+      Trebuchet.feature('test').strategy.is_a?(Trebuchet::Strategy::Stub)
+    end
+
+  end
+
+  describe '#stubbed?' do
+
+    it "should report when features are stubbed launched" do
+      Trebuchet.feature('test').stub(:launched)
+      Trebuchet.feature('test').should be_stubbed
+    end
+
+    it "should report when features are stubbed not launched" do
+      Trebuchet.feature('test').stub(:not_launched)
+      Trebuchet.feature('test').should be_stubbed
+    end
+
+  end
+
+  describe '#dismantle_stubs' do
+
+    it "should reset stubbed features" do
+      Trebuchet.feature('test').stub(:launched)
+      Trebuchet.dismantle_stubs
+      Trebuchet::Feature.stubbed_features.should be_empty
+    end
+
+    it "should restore them to their default state" do
+      Trebuchet.feature('test').stub(:launched)
+      Trebuchet.dismantle_stubs
+      should_not_launch('test', [0])
+    end
+
+  end
+
+  describe '#stubbed_features' do
+
+    it "should report when feature are stubbed" do
+      Trebuchet.feature('test').stub(:launched)
+      Trebuchet::Feature.stubbed_features.count.should == 1
+    end
+
+    it "should report when features are stubbed launched" do
+      Trebuchet.feature('test').stub(:launched)
+      Trebuchet::Feature.stubbed_features['test'].should == :launched
+    end
+
+    it "should report when features are stubbed not launched" do
+      Trebuchet.feature('test').stub(:not_launched)
+      Trebuchet::Feature.stubbed_features['test'].should == :not_launched
+    end
+
+  end
+
+end


### PR DESCRIPTION
I'm not here to convince you of the value of stubbing Trebuchet. That practice is essential and well-established. Instead, I want to talk about the advantages of dropping our ad-hoc `rspec-mocks` stubs for a facility that's internal to Trebuchet itself.

Why? The current situation is gnarly and the variety is manifold, but I have an ulterior motive as well.

I'd like to make it easy to support and maintain hacks like this — http://www.github.com/airbnb/trebuchet-roulette.
### A short survey of the gnarly

We have at least four distinct patterns for stubbing Trebuchet in Monorail:
- `stub_all_trebuchet`
- `stub_trebuchet( ... )`
- `Trebuchet.any_instance.stub(:launch?) { ... }`
- `Trebuchet.stub_chain(:current, :launch?).and_return( ... )`

And the always popular not-a-stub-stub:
- `Trebuchet.aim( ... , :users, [2, 3])`

Let's put aside the fact that `stub_all_trebuchet` is a demon spawn, at least for the moment.

While each of these methods has the desired effect, it makes it very difficult for other parts of our testing infrastructure to determine when a feature is stubbed. In some cases — I'm looking at you, `stub_all_trebuchet` — the method is so blunt as to defeat the purpose of testing controlled examples.
### A blessed stubbing interface

My ideal Trebuchet stubbing interface would:
- Be singular.
- Permit introspecting which features are currently stubbed.
- Actively interfere with and/or resist stubbing by other means.

I want to propose a new way to stub Trebuchet. The syntax is simple:

```
Trebuchet.feature('my_darling_feature').stub(:launched)
```

To reset stubbing, you call:

```
Trebuchet.dismantle_stubs
```

And that's it.

I made several attempts to introduce the final behavior I listed above, but `rspec-mocks` is a wily beast. Disallowing stubbing on any particular instance is trivial and in fact, you can look back at these commits for an example. However, defeating the `#any_instance` stubber is more involved. I'm willing to admit that this kind of tomfoolery doesn't belong in Trebuchet.

Though, if there's interest, I can continue to investigate what it would take to do it in Monorail...
### But wait, there's more

Once we start to use this interface (even in just a few places), many interesting possibilities open before us. At any time, we can inquire as to which features (and which states) are under _deliberate_ consideration by any particular test example:

```
Trebuchet::Feature.stubbed_features
=> { 'my_darling_feature' => :launched }
```

... and which are not! This, of course, allows `trebuchet-roulette` to work its magic.
### Spin the wheel

The rationale for  `trebuchet-roulette` is written up in its repository, but in the event that you're terminally lazy or just late for a wedding, I've reproduced one of the examples here. :)

Consider the following test:

```
it "should succeed due to an assumption" do
   some_condition = trebuchet.launch?('false_by_default')
   some_condition.should be_false
end
```

This test passes because all Trebuchet experiments are unlaunched by default, but the very same expectation will fail when that particular feature is launched.

Let's see what happens when we enable `trebuchet-roulette`:

```
describe 'the panoply of all possibility' do
  with_trebuchet_roulette

  it "should succeed due to an assumption" do
    some_condition = trebuchet.launch?('false_by_default')
    some_condition.should be_false
  end
end
```

The output now reveals the truth for what it is:

```
Failures:

  1) the panoply of all possibility should succeed due to an assumption (false_by_default=true)
     Failure/Error: some_condition.should be_false
       expected: false value
            got: true
```

Let's put an end to surprise assaults from Trebuchet!

_"Green Builds should be safe to deploy."_ —Anonymous
