### PR TITLE
Allow fetching history across features

### DIFF
--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -123,6 +123,13 @@ class Trebuchet
     end
   end
 
+  def self.history(include_archived = false)
+    return [] unless Trebuchet.backend.respond_to?(:get_all_history)
+    Trebuchet.backend.get_all_history(include_archived).map do |row|
+      [Time.at(row.first), Feature.find(row.last)]
+    end
+  end
+
 end
 
 require 'set'

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
   
-  VERSION = "0.6.5"
+  VERSION = "0.6.6"
   
 end


### PR DESCRIPTION
The history does not include the full strategy information; only the timestamps when changes occurred.
