### PR TITLE
Update redis backend to update a sentinel key to indicate modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.1 (Jul 21, 2015)
+  - update redis backend to update a sentinel to indicate modifications
+
 ## 0.8.0 (Jul 20, 2015)
   - adds a new backened redis_hammerspaced
 

--- a/lib/trebuchet/backend/redis.rb
+++ b/lib/trebuchet/backend/redis.rb
@@ -122,8 +122,7 @@ class Trebuchet::Backend::Redis
   end
 
   def get_sentinel
-    v = @redis.get(sentinel_key)
-    v || Time.now.to_i
+    @redis.get(sentinel_key) || Time.now.to_i
   end
 
   private
@@ -147,7 +146,7 @@ class Trebuchet::Backend::Redis
   end
 
   def sentinel_key
-    "#{namespace}sentinel"
+    "#{namespace}last_updated"
   end
 
 end

--- a/lib/trebuchet/backend/redis.rb
+++ b/lib/trebuchet/backend/redis.rb
@@ -48,6 +48,7 @@ class Trebuchet::Backend::Redis
   def set_strategy(feature_name, strategy, options = nil)
     remove_strategy(feature_name)
     append_strategy(feature_name, strategy, options)
+    update_sentinel
   end
 
   def append_strategy(feature_name, strategy, options = nil)
@@ -55,10 +56,12 @@ class Trebuchet::Backend::Redis
     @redis.hset(feature_key(feature_name), strategy, [options].to_json) # have to put options in container for json
     @redis.sadd(feature_names_key, feature_name)
     store_history(feature_name)
+    update_sentinel
   end
   
   def remove_strategy(feature_name)
     @redis.del(feature_key(feature_name))
+    update_sentinel
   end
   
   def get_feature_names
@@ -73,6 +76,7 @@ class Trebuchet::Backend::Redis
     @redis.del(feature_key(feature_name))
     @redis.srem(feature_names_key, feature_name)
     @redis.sadd(archived_feature_names_key, feature_name)
+    update_sentinel
   end
   
   def store_history(feature_name)
@@ -113,6 +117,15 @@ class Trebuchet::Backend::Redis
     history.sort! { |x,y| y.first <=> x.first }
   end
 
+  def update_sentinel
+    @redis.set(sentinel_key, Time.now.to_i)
+  end
+
+  def get_sentinel
+    v = @redis.get(sentinel_key)
+    v || Time.now.to_i
+  end
+
   private
   
   def archived_feature_names_key
@@ -131,6 +144,10 @@ class Trebuchet::Backend::Redis
     key = "#{namespace}feature-history/#{feature_name}"
     key = "#{key}/#{timestamp}" if timestamp
     key
+  end
+
+  def sentinel_key
+    "#{namespace}sentinel"
   end
 
 end

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 
 end


### PR DESCRIPTION
Whenever we make change to trebuchet with redis backend, we now update a sentinel key with the latest timestamp. This won't have any affect on existing applications. But for newer applications that use redis_hammerspaced backend, their cron jobs will take advantage of this sentinel value to infer if there's any modification since last refresh.