### PR TITLE
cache feature objects for reuse

### DIFF
--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -1,6 +1,12 @@
+require 'digest/sha1'
+
 class Trebuchet
 
   @@visitor_id = nil
+
+  # initialize a single one to save object allocations
+  # Todo perhaps choose a better hash instead of sha1
+  SHA1 = Digest::SHA1.new
 
   class << self
     attr_accessor :admin_view, :admin_edit

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -14,7 +14,7 @@ class Trebuchet::Feature
 
   def self.find(name)
     feature = @@features[name]
-    if not feature
+    if !feature
       feature = new(name)
       @@features[name] = feature
     end

--- a/lib/trebuchet/strategy.rb
+++ b/lib/trebuchet/strategy.rb
@@ -87,7 +87,7 @@ module Trebuchet::Strategy
 
     def value_in_range?(value)
       bucket =
-          Digest::SHA1.hexdigest("#{@feature.name}|#{value}").to_i(16) % 100
+          Trebuchet::SHA1.hexdigest("#{@feature.name}|#{value}").to_i(16) % 100
       bucket < @percentage
     end
 
@@ -205,7 +205,7 @@ module Trebuchet::Strategy
       return false if value == nil || !value.is_a?(Numeric)
       return false unless self.valid?
       # must hash feature name and value together to ensure uniform distribution
-      b = Digest::SHA1.hexdigest("experiment: #{@experiment_name.downcase} user: #{value}").to_i(16) % total_buckets
+      b = Trebuchet::SHA1.hexdigest("experiment: #{@experiment_name.downcase} user: #{value}").to_i(16) % total_buckets
       !!@bucket.include?(b + 1) # is user in this bucket?
     end
 

--- a/lib/trebuchet/strategy/base.rb
+++ b/lib/trebuchet/strategy/base.rb
@@ -1,17 +1,15 @@
 require 'digest/sha1'
 
 class Trebuchet::Strategy::Base
-  
+
   attr_accessor :feature
-  
+
   def name
     self.class.strategy_name
   end
-  
+
   def feature_id
-    Digest::SHA1.hexdigest(@feature.name).to_i(16)
-  rescue
-    return 0
+    feature.feature_id
   end
 
   def needs_user?
@@ -21,7 +19,7 @@ class Trebuchet::Strategy::Base
   def self.strategy_name
     Trebuchet::Strategy.name_for_class(self)
   end
-  
+
   def as_json(options = {})
     excluded = [:feature, :block]
     {:name => name}.tap do |h|
@@ -39,5 +37,5 @@ class Trebuchet::Strategy::Base
   def export(options = nil)
     {:name => self.name, :options => options}
   end
-  
+
 end


### PR DESCRIPTION
cache feature objects for reuse to save object allocations. Also save the feature_id hash and use a static sha object to save digest allocations

@jtai @nelgau 