### PR TITLE
Provide author to backend for bookkeeping

### DIFF
--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -15,16 +15,7 @@ class Trebuchet
     attr_accessor :current_block
 
     # Who are making the changes.
-    attr_reader :author
-
-    def set_author(author)
-      @author = author
-      if backend.respond_to?(:author=)
-        backend.author = author
-      end
-    end
-
-    alias_method :author=, :set_author
+    attr_accessor :author
 
     def backend
       self.backend = :memory unless @backend
@@ -38,9 +29,6 @@ class Trebuchet
       elsif backend_type.class.name =~ /Trebuchet::Backend/
         @backend = backend_type
       end
-
-      # Resetting author to update the new backend.
-      self.set_author(@author)
     end
 
     # this only works with additional args, e.g.: Trebuchet.backend = :memory

--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -14,6 +14,18 @@ class Trebuchet
     attr_accessor :exception_handler
     attr_accessor :current_block
 
+    # Who are making the changes.
+    attr_reader :author
+
+    def set_author(author)
+      @author = author
+      if backend.respond_to?(:author=)
+        backend.author = author
+      end
+    end
+
+    alias_method :author=, :set_author
+
     def backend
       self.backend = :memory unless @backend
       @backend
@@ -26,6 +38,9 @@ class Trebuchet
       elsif backend_type.class.name =~ /Trebuchet::Backend/
         @backend = backend_type
       end
+
+      # Resetting author to update the new backend.
+      self.set_author(@author)
     end
 
     # this only works with additional args, e.g.: Trebuchet.backend = :memory

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 
 end


### PR DESCRIPTION
This is so that we can pass in author's info in the rails initializer for trebuchet admin dashboard and console sessions.

## Test

Add `attr_accessor :author` to the memory based backend temporarily and check in rails console that `Trebuchet.author = xxx` calls propagates to `Trebuchet.backend.author`.

@nwadams (since you most recently touched this repo) @SonicWang @jtai @liukai 