### PR TITLE
Generalize the refresh method for Backend

### DIFF
--- a/lib/trebuchet/action_controller_filter.rb
+++ b/lib/trebuchet/action_controller_filter.rb
@@ -3,23 +3,8 @@ class Trebuchet::ActionControllerFilter
   def self.before(controller)
     Trebuchet.initialize_logs
 
-    if (
-        defined?(Trebuchet::Backend::RedisCached) &&
-        Trebuchet.backend.is_a?(Trebuchet::Backend::RedisCached) &&
-        Trebuchet.backend.respond_to?(:clear_cached_strategies)
-       )
-      if Time.now > Trebuchet.backend.cache_cleared_at + 60.seconds
-        Trebuchet.backend.clear_cached_strategies
-      end
-    end
-
-    # Lazy local cache invalidation for RedisHammerspaced
-    if (
-        defined?(Trebuchet::Backend::RedisHammerspaced) &&
-        Trebuchet.backend.is_a?(Trebuchet::Backend::RedisHammerspaced) &&
-        Trebuchet.backend.respond_to?(:refresh)
-       )
-       Trebuchet.backend.refresh
+    if Trebuchet.backend.respond_to?(:refresh)
+      Trebuchet.backend.refresh
     end
 
     Trebuchet.current_block = Proc.new {

--- a/lib/trebuchet/backend/redis.rb
+++ b/lib/trebuchet/backend/redis.rb
@@ -2,9 +2,9 @@ require 'redis' unless defined?(Redis)
 require 'json'
 
 class Trebuchet::Backend::Redis
-  
+
   attr_accessor :namespace
-  
+
   def initialize(*args)
     @namespace = 'trebuchet/'
     begin
@@ -16,7 +16,7 @@ class Trebuchet::Backend::Redis
         @redis = Redis.new(*args)
       end
       unless @options && @options[:skip_check]
-        # raise error if not connectedUncaught ReferenceError: google is not defined 
+        # raise error if not connectedUncaught ReferenceError: google is not defined
         @redis.exists(feature_names_key) # @redis.info is slow and @redis.client.connected? is NOT reliable
       end
     rescue Exception => e
@@ -28,7 +28,7 @@ class Trebuchet::Backend::Redis
     return nil unless h = @redis.hgetall(feature_key(feature_name))
     unpack_strategy(h)
   end
-  
+
   def unpack_strategy(options)
     return nil unless options.is_a?(Hash)
     [].tap do |a|
@@ -58,34 +58,34 @@ class Trebuchet::Backend::Redis
     store_history(feature_name)
     update_sentinel
   end
-  
+
   def remove_strategy(feature_name)
     @redis.del(feature_key(feature_name))
     update_sentinel
   end
-  
+
   def get_feature_names
     @redis.smembers(feature_names_key)
   end
-  
+
   def get_archived_feature_names
     @redis.smembers(archived_feature_names_key)
   end
-  
+
   def remove_feature(feature_name)
     @redis.del(feature_key(feature_name))
     @redis.srem(feature_names_key, feature_name)
     @redis.sadd(archived_feature_names_key, feature_name)
     update_sentinel
   end
-  
+
   def store_history(feature_name)
     timestamp = Time.now.to_i
     h = @redis.hgetall(feature_key(feature_name))
     @redis.hmset(feature_history_key(feature_name, timestamp), *h.to_a.flatten)
     @redis.sadd(feature_history_key(feature_name), timestamp) # subtle
   end
-  
+
   def get_history(feature_name)
     [].tap do |history|
       @redis.smembers(feature_history_key(feature_name)).sort.each do |timestamp|
@@ -126,19 +126,19 @@ class Trebuchet::Backend::Redis
   end
 
   private
-  
+
   def archived_feature_names_key
     "#{namespace}archived-feature-names"
   end
-  
+
   def feature_names_key
     "#{namespace}feature-names"
   end
-  
+
   def feature_key(feature_name)
     "#{namespace}features/#{feature_name}"
   end
-  
+
   def feature_history_key(feature_name, timestamp = nil)
     key = "#{namespace}feature-history/#{feature_name}"
     key = "#{key}/#{timestamp}" if timestamp

--- a/lib/trebuchet/backend/redis_cached.rb
+++ b/lib/trebuchet/backend/redis_cached.rb
@@ -40,4 +40,8 @@ class Trebuchet::Backend::RedisCached < Trebuchet::Backend::Redis
     @cached_strategies = nil
   end
 
+  def refresh
+    clear_cached_strategies if Time.now > cache_cleared_at + 60.seconds
+  end
+
 end


### PR DESCRIPTION
This PR is a second attempt to generalize the refresh operation when running `before` filter.
In this PR I generalized `refresh()` method, which should be way more easy and clear than the one proposed in #23 

I did code search, and this change should be compatible all existing code.

@jtai @SonicWang 