### PR TITLE
Don't use the root named route. Future Rails versions don't let you h…

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 routes_block = lambda do
   scope "trebuchet", :module => "trebuchet_rails" do
-    root :to => "features#index"
+    get '/' => "features#index"
     get 'timeline' => "features#timeline"
   end
 end

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 
 end


### PR DESCRIPTION
…ave named route collisions.

@nelgau this should keep the same route but not take the `root` name