### PR TITLE
Support adding comments to features 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.6 (April 5, 2016)
+  - add :add_comment method to the Feature class
+
 ## 0.9.2 (October 11, 2015)
   - add :nobody and :everybody strategies
   - cache features

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -111,6 +111,13 @@ class Trebuchet::Feature
     Trebuchet.backend.remove_feature(self.name)
   end
 
+  # add comments for a feature, as a place to hold change logs for example, to supported backends
+  def add_comment(comment)
+    if Trebuchet.backend.respond_to?(:add_comment)
+      Trebuchet.backend.add_comment(self.name, comment)
+    end
+  end
+
   def history
     return [] unless Trebuchet.backend.respond_to?(:get_history)
     Trebuchet.backend.get_history(self.name).map do |row|

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.5"
+  VERSION = "0.9.6"
 
 end


### PR DESCRIPTION
Add `Feature::add_comment` so that supported backends can use it to take in change logs. 

Implementation in `sitar-trebuchet-backed`:  https://git.musta.ch/airbnb/sitar-trebuchet-backend/pull/18.

@liukai @jianAir @jtai @airbnb/product-infra 