### PR TITLE
Convert deserialized strategy names to symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.8 (July 27, 2016)
+  - convert deserialized strategy names to symbols
+
 ## 0.9.7 (July 20, 2016)
   - logic operation strategies, e.g. AND, OR, and NOT
 

--- a/lib/trebuchet/strategy/logic_base.rb
+++ b/lib/trebuchet/strategy/logic_base.rb
@@ -5,7 +5,7 @@ class Trebuchet::Strategy::LogicBase < Trebuchet::Strategy::Base
   def initialize(options = {})
     @strategies = []
     options.each do |strategy_name, strategy_options|
-      @strategies << Trebuchet::Strategy.find(strategy_name, strategy_options)
+      @strategies << Trebuchet::Strategy.find(strategy_name.to_sym, strategy_options)
     end
   end
 

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.7"
+  VERSION = "0.9.8"
 
 end

--- a/spec/logic_and_strategy_spec.rb
+++ b/spec/logic_and_strategy_spec.rb
@@ -36,11 +36,11 @@ describe Trebuchet::Strategy::LogicAnd do
     Trebuchet.feature('pokemon').aim(
       :logic_and,
       {
-        percent: 100,
-        logic_and: {
-          users: [90, 91, 92],
-          logic_not: {
-            users: [90],
+        "percent" => 100,
+        "logic_and" => {
+          "users" => [90, 91, 92],
+          "logic_not" => {
+            "users" => [90],
           },
         },
       },


### PR DESCRIPTION
Since `Strategy.find` uses symbols to key strategies but symbols would be lost in ser/de with json.