### PR TITLE
[minor] Keep raw option hash in logic strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.9 (Sep 15, 2016)
+  - minor change: keep raw option hash in logic strategies for editing purpose
+
 ## 0.9.8 (July 27, 2016)
   - convert deserialized strategy names to symbols
 

--- a/lib/trebuchet/strategy/logic_base.rb
+++ b/lib/trebuchet/strategy/logic_base.rb
@@ -1,8 +1,10 @@
 class Trebuchet::Strategy::LogicBase < Trebuchet::Strategy::Base
 
   attr_reader :strategies
+  attr_reader :options
 
   def initialize(options = {})
+    @options = options
     @strategies = []
     options.each do |strategy_name, strategy_options|
       @strategies << Trebuchet::Strategy.find(strategy_name.to_sym, strategy_options)

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.8"
+  VERSION = "0.9.9"
 
 end


### PR DESCRIPTION
Currently, there's no unified way of converting strategy objects back to raw options. For the logical strategies, we keep the raw option hash so that edits can be done on the option hash and consequently be applied back to its belonging feature via `Trebuchet.aim`.