### PR TITLE
Logical operator fix for visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.10 (Nov 14, 2016)
+  - fix logical operators for logged out visitors
+
 ## 0.9.9 (Sep 15, 2016)
   - minor change: keep raw option hash in logic strategies for editing purpose
 

--- a/lib/trebuchet/strategy/logic_and.rb
+++ b/lib/trebuchet/strategy/logic_and.rb
@@ -4,8 +4,7 @@ class Trebuchet::Strategy::LogicAnd < Trebuchet::Strategy::LogicBase
 
   def launch_at?(user, request = nil)
     @strategies
-      .select { |s| !user.nil? || !s.needs_user? }
-      .all? { |s| s.launch_at?(user, request) }
+      .all? { |s| (!s.needs_user? || !user.nil?) && s.launch_at?(user, request) }
   end
 
 end

--- a/lib/trebuchet/strategy/logic_base.rb
+++ b/lib/trebuchet/strategy/logic_base.rb
@@ -22,7 +22,7 @@ class Trebuchet::Strategy::LogicBase < Trebuchet::Strategy::Base
   end
 
   def needs_user?
-    true # Always require a user to avoid confusions.
+    false
   end
 
 end

--- a/lib/trebuchet/strategy/logic_not.rb
+++ b/lib/trebuchet/strategy/logic_not.rb
@@ -4,8 +4,7 @@ class Trebuchet::Strategy::LogicNot < Trebuchet::Strategy::LogicBase
 
   def launch_at?(user, request = nil)
     @strategies
-      .select { |s| !user.nil? || !s.needs_user? }
-      .none? { |s| s.launch_at?(user, request) }
+      .none? { |s| (!s.needs_user? || !user.nil?) && s.launch_at?(user, request) }
   end
 
 end

--- a/lib/trebuchet/strategy/logic_or.rb
+++ b/lib/trebuchet/strategy/logic_or.rb
@@ -4,8 +4,7 @@ class Trebuchet::Strategy::LogicOr < Trebuchet::Strategy::LogicBase
 
   def launch_at?(user, request = nil)
     @strategies
-      .select { |s| !user.nil? || !s.needs_user? }
-      .any? { |s| s.launch_at?(user, request) }
+      .any? { |s| (!s.needs_user? || !user.nil?) && s.launch_at?(user, request) }
   end
 
 end

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.9"
+  VERSION = "0.9.10"
 
 end

--- a/spec/logic_base_strategy_spec.rb
+++ b/spec/logic_base_strategy_spec.rb
@@ -24,6 +24,7 @@ describe Trebuchet::Strategy::LogicBase do
 
     Trebuchet::Strategy.should_receive(:find).with(*args).and_return(strategy)
     strategy.should_receive(:launch_at?).with(user, request)
+    strategy.should_receive(:needs_user?).and_return(false)
 
     s = Trebuchet::Strategy::LogicOr.new({foo: 1})
     s.launch_at?(user, request)


### PR DESCRIPTION
`Feature.launch_at?` uses its strategy's `needs_user?` method to do short-circuiting decision making (https://github.com/airbnb/trebuchet/blob/master/lib/trebuchet/feature.rb#L65). And in order to make logical operators work properly with logged out visitors, all these container strategy types should declare as not needing the user object, and check for the user object only at terminal strategies.

@liukai @jianAir @liangg @mosnicholas