### PR TITLE
[minor] Reduce number of backend calls in launch_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.11 (Nov 16, 2016)
+  - minor change: reduce number of times backend is hit in the launch methods
+
 ## 0.9.10 (Nov 14, 2016)
   - fix logical operators for logged out visitors
 

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -62,7 +62,9 @@ class Trebuchet::Feature
   end
 
   def launch_at?(user, request = nil)
-    (!strategy.needs_user? || !user.nil?) && strategy.launch_at?(user, request)
+    # Store strategy so that only one call to the backend is needed.
+    s = strategy
+    (!s.needs_user? || !user.nil?) && s.launch_at?(user, request)
   end
 
   def aim(strategy_name, options = nil)

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.10"
+  VERSION = "0.9.11"
 
 end


### PR DESCRIPTION
The launch and launch? methods of trebuchet both trigger
two duplicate calls to the backend. This commit cuts it down to one backend
call per launch and launch?.

Tested by running a launch and checking the number of backend calls.

@tay @jiayou50 