### PR TITLE
Add CustomRequestAware strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.17 (Aug 15, 2017)
+  - adds CustomRequestAware strategy
+
 ## 0.9.16 (Aug 9, 2017)
   - Don't raise an error if expiration date has not been previously set
 

--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -76,6 +76,10 @@ class Trebuchet
     Strategy::Custom.define(name, block)
   end
 
+  def self.define_request_aware_strategy(name, &block)
+    Strategy::CustomRequestAware.define(name, block)
+  end
+
   def self.visitor_id=(id_or_proc)
     if id_or_proc.is_a?(Proc)
       @@visitor_id = id_or_proc
@@ -156,6 +160,7 @@ require 'trebuchet/feature'
 require 'trebuchet/strategy'
 require 'trebuchet/strategy/base'
 require 'trebuchet/strategy/custom'
+require 'trebuchet/strategy/custom_request_aware'
 require 'trebuchet/strategy/default'
 require 'trebuchet/strategy/everyone'
 require 'trebuchet/strategy/experiment'

--- a/lib/trebuchet/strategy.rb
+++ b/lib/trebuchet/strategy.rb
@@ -24,6 +24,8 @@ module Trebuchet::Strategy
       Everyone.instance
     elsif strategy_name == :nobody
       Nobody.instance
+    elsif CustomRequestAware.exists?(strategy_name)
+      CustomRequestAware.new(strategy_name, options)
     elsif Custom.exists?(strategy_name)
       Custom.new(strategy_name, options)
     elsif klass = class_for_name(strategy_name)

--- a/lib/trebuchet/strategy/custom.rb
+++ b/lib/trebuchet/strategy/custom.rb
@@ -21,7 +21,7 @@ class Trebuchet::Strategy::Custom < Trebuchet::Strategy::Base
   def self.exists?(name)
     @@custom_strategies.has_key?(name)
   end
-  
+
   def needs_user?
     false
     # re-enable after adding  { |options, user, request| }

--- a/lib/trebuchet/strategy/custom_request_aware.rb
+++ b/lib/trebuchet/strategy/custom_request_aware.rb
@@ -1,0 +1,26 @@
+class Trebuchet::Strategy::CustomRequestAware < Trebuchet::Strategy::Custom
+  @@custom_request_aware_strategies = {}
+
+  def initialize(name, options = nil)
+    @custom_name = name
+    @options = options
+    @block = @@custom_request_aware_strategies[name]
+  end
+
+  def self.define(name, block)
+    @@custom_request_aware_strategies[name] = block
+  end
+
+  def self.exists?(name)
+    @@custom_request_aware_strategies.has_key?(name)
+  end
+
+  def launch_at?(user, request = nil)
+    request ||= {}
+    !!(options ? @block.call(user, request, options) : @block.call(user, request))
+  end
+
+  def to_s
+    "#{custom_name} (custom_request_aware) #{options.inspect if options}"
+  end
+end

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.16"
+  VERSION = "0.9.17"
 
 end

--- a/spec/custom_request_aware_strategy_spec.rb
+++ b/spec/custom_request_aware_strategy_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Trebuchet::Strategy::CustomRequestAware do
+  it "should launch according to the custom strategy with options" do
+    Trebuchet.define_request_aware_strategy(:ip_address_strategy) do |current_user, request, ip_address|
+      request[:ip_address] == ip_address
+    end
+
+    Trebuchet.aim('ip_limited_feature', :ip_address_strategy, '1.1.1.1')
+
+    Trebuchet.new(User.new, { :ip_address => '1.1.1.1' }).launch?('ip_limited_feature')
+      .should be_true
+    Trebuchet.new(User.new, { :ip_address => '2.2.2.2' }).launch?('ip_limited_feature')
+      .should be_false
+  end
+
+  it "should launch according to the custom strategy without options" do
+    Trebuchet.define_request_aware_strategy(:ip_address_strategy) do |current_user, request|
+      request[:ip_address] == '1.1.1.1'
+    end
+
+    Trebuchet.aim('ip_limited_feature', :ip_address_strategy)
+
+    Trebuchet.new(User.new, { :ip_address => '1.1.1.1' }).launch?('ip_limited_feature')
+      .should be_true
+    Trebuchet.new(User.new, { :ip_address => '2.2.2.2' }).launch?('ip_limited_feature')
+      .should be_false
+  end
+
+  it "should not explode when request is nil" do
+    Trebuchet.define_request_aware_strategy(:ip_address_strategy) do |current_user, request|
+      request[:ip_address] == '1.1.1.1'
+    end
+
+    Trebuchet.aim('ip_limited_feature', :ip_address_strategy)
+
+    Trebuchet.new(User.new).launch?('ip_limited_feature').should be_false
+  end
+end


### PR DESCRIPTION
## Why

We pass a `user` and a `request` object when initializing a trebuchet. `User` is expected to contain user-related information, such as registration country and locale, while `request` is expected to contain request-specific information, such as ip address, user-agent. Currently, we could define a `Custom` strategy with  `user` object as context. For example, a launch strategy based user's registration country. A `Custom` strategy is defined by providing a callback block, e.g: https://github.com/airbnb/trebuchet/blob/d2366323be50bdbf62059c4ab9665ad9d1bbf298/spec/custom_strategy_spec.rb#L6 However, this strategy does not pass the `request` object as parameter to the callback ( https://github.com/airbnb/trebuchet/blob/master/lib/trebuchet/strategy/custom.rb#L14). As a result, we are not able to define a customized strategy based on information in the `request` object.

## What

This PR adds a new `CustomRequestAware` strategy. Compared to the existing `Custom` strategy, this strategy passes `user` as well as `request` to the custom block in `launch_at?`. This strategy will be useful when we want to launch a feature based on request-specific information, such as request's IP address and user-agent.

## How

`CustomRequestAware` inherits from `Trebuchet::Strategy::Custom`, with similar implementation. It stores strategy names in a class variable `custom_request_aware_strategies`. A `CustomRequestAware` strategy is defined by calling 
`Trebuchet.define_request_aware_strategy(:strategy_name)` with a block accepting `user, request, option` as parameters.
