### PR TITLE
[trebuchet] Return expiration date config payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.15 (Aug 9, 2017)
+  - Return payload for expiration date accessor
+
 ## 0.9.14 (Aug 9, 2017)
   - Expose expiration date accessor
 

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -122,7 +122,7 @@ class Trebuchet::Feature
 
   def expiration_date
     return unless Trebuchet.backend.respond_to?(:expiration_date)
-    Trebuchet.backend.expiration_date(self.name)
+    Trebuchet.backend.expiration_date(self.name).payload
   end
 
   def set_expiration_date(expiration_date)

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.14"
+  VERSION = "0.9.15"
 
 end


### PR DESCRIPTION
Return expiration date sitar config payload (which contains the string timestamp) instead of the config object

@wang103