### PR TITLE
[trebuchet] Return expiration date if config exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.00 (Aug 9, 2017)
+  - Return expiration date config payload if the config exists
+
 ## 0.9.15 (Aug 9, 2017)
   - Return payload for expiration date accessor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.9.16 (Aug 9, 2017)
-  - Return expiration date config payload if the config exists
+  - Don't raise an error if expiration date has not been previously set
 
 ## 0.9.15 (Aug 9, 2017)
   - Return payload for expiration date accessor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.00 (Aug 9, 2017)
+## 0.9.16 (Aug 9, 2017)
   - Return expiration date config payload if the config exists
 
 ## 0.9.15 (Aug 9, 2017)

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -122,7 +122,7 @@ class Trebuchet::Feature
 
   def expiration_date
     return unless Trebuchet.backend.respond_to?(:expiration_date)
-    Trebuchet.backend.expiration_date(self.name).payload
+    Trebuchet.backend.expiration_date(self.name).try(:payload)
   end
 
   def set_expiration_date(expiration_date)

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "1.0.00"
+  VERSION = "0.9.16"
 
 end

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.15"
+  VERSION = "1.0.00"
 
 end


### PR DESCRIPTION
use `.try` to ensure returning the expiration config payload if config has been set previously

@kmsun07