### PR TITLE
[Trebuchet] [expiration_date] Do not expose our internal data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0 (Sep 18, 2017)
+  - Return DateTime type for method expiration_date
+
 ## 0.9.17 (Aug 15, 2017)
   - adds CustomRequestAware strategy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.10.0 (Sep 18, 2017)
-  - Return DateTime type for method expiration_date
+## 0.9.18 (Sep 18, 2017)
+  - Do not expose internal format
 
 ## 0.9.17 (Aug 15, 2017)
   - adds CustomRequestAware strategy

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -120,7 +120,7 @@ class Trebuchet::Feature
     end
   end
 
-  # Retrieve the expiration date of the feature as a +DateTime+ object.
+  # Retrieve the expiration date of the feature.
   # Return nil if the feature does not have an expiration date.
   def expiration_date
     return unless Trebuchet.backend.respond_to?(:expiration_date)
@@ -128,8 +128,6 @@ class Trebuchet::Feature
   end
 
   # Set the expiration date of the feature.
-  # Params:
-  # +expiration_date+:: +DateTime+ object indicating the expiration date
   def set_expiration_date(expiration_date)
     return unless Trebuchet.backend.respond_to?(:set_expiration_date)
     Trebuchet.backend.set_expiration_date(self.name, expiration_date)

--- a/lib/trebuchet/feature.rb
+++ b/lib/trebuchet/feature.rb
@@ -120,11 +120,16 @@ class Trebuchet::Feature
     end
   end
 
+  # Retrieve the expiration date of the feature as a +DateTime+ object.
+  # Return nil if the feature does not have an expiration date.
   def expiration_date
     return unless Trebuchet.backend.respond_to?(:expiration_date)
-    Trebuchet.backend.expiration_date(self.name).try(:payload)
+    Trebuchet.backend.expiration_date(self.name)
   end
 
+  # Set the expiration date of the feature.
+  # Params:
+  # +expiration_date+:: +DateTime+ object indicating the expiration date
   def set_expiration_date(expiration_date)
     return unless Trebuchet.backend.respond_to?(:set_expiration_date)
     Trebuchet.backend.set_expiration_date(self.name, expiration_date)

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.17"
+  VERSION = "0.10.0"
 
 end

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.10.0"
+  VERSION = "0.9.18"
 
 end


### PR DESCRIPTION
Essentially, I'd like to revert the changes from this PR: https://github.com/airbnb/trebuchet/pull/40/files

Reasoning:
Anyone using this trebuchet gem can provide their own trebuchet backend. If their backend chose to implement `expiration_date` method, we should not force them to have this `payload` attribute.

This `payload` attribute comes from our internal system. I already fixed our internal trebuchet backend such that its `expiration_date` method won't return an object with `payload`, it would simply return the actual date.

So it's safe to remove it here.

@hijookim @kmsun07 
