### PR TITLE
Cache Trebuchet#launch?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0 (Nov 17, 2017)
+  - Cache Trebuchet#launch?
+
 ## 0.9.18 (Sep 18, 2017)
   - Do not expose internal format
 

--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -107,7 +107,7 @@ class Trebuchet
   def initialize(current_user, request = nil)
     @current_user = current_user
     @request = request
-    @logs = {}
+    @result_cache = {}
   end
 
   def launch(feature, &block)
@@ -117,9 +117,15 @@ class Trebuchet
   end
 
   def launch?(feature)
-    result = !!Feature.find(feature).launch_at?(@current_user, @request)
-    Trebuchet.log(feature, result)
-    return result
+    result = @result_cache[feature]
+
+    if result.nil?
+      result = @result_cache[feature] =
+        !!Feature.find(feature).launch_at?(@current_user, @request)
+      Trebuchet.log(feature, result)
+    end
+
+    result
   rescue => e
     handle_exception(e, feature)
     return false

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.9.18"
+  VERSION = "0.10.0"
 
 end

--- a/spec/trebuchet_spec.rb
+++ b/spec/trebuchet_spec.rb
@@ -13,7 +13,18 @@ describe Trebuchet do
       Trebuchet::Feature.any_instance.should_receive(:launch_at?).once
       Trebuchet.new(nil).launch?('highly_experimental')
     end
-    
+
+    it "caches value of launch_at?" do
+      t = Trebuchet.new(nil)
+      Trebuchet.feature('highly_experimental').should_receive(:launch_at?).once
+      Trebuchet.feature('waste_of_time').should_receive(:launch_at?).once
+
+      t.launch?('highly_experimental')
+      t.launch?('waste_of_time')
+
+      t.launch?('highly_experimental')
+      t.launch?('waste_of_time')
+    end
   end
     
   describe "launch" do

--- a/spec/visitor_experiment_strategy_spec.rb
+++ b/spec/visitor_experiment_strategy_spec.rb
@@ -6,23 +6,24 @@ describe Trebuchet::Strategy::VisitorExperiment do
     @feature_name = "Infrared Vision"
     @feature_name2 = "Alligator Tail"
     @experiment_name = "Superhumanity"
-    @trebuchet = Trebuchet.new(User.new(0), mock_request('abcdef'))
+    @user = User.new(0)
+    @mock_request = mock_request('abcdef')
+    @trebuchet = Trebuchet.new(@user, @mock_request)
   end
 
   it "should match a user in a bucket" do
     Trebuchet.aim(@feature_name, :visitor_experiment, :name => @experiment_name, :bucket => 1)
-    strategy = Trebuchet.feature(@feature_name).strategy
     should_not_launch(@feature_name, (1..50).to_a) # should never launch without a request
     # these values just happen to hash for the algorithm and experiment name
     positive = [5, 14, 15, 198, 200, 549]
     negative = [1, 2, 25, 550]
     positive.each do |i|
       Trebuchet.visitor_id = i
-      @trebuchet.launch?(@feature_name).should be_true
+      Trebuchet.feature(@feature_name).launch_at?(@user, @mock_request).should be_true
     end
     negative.each do |i|
       Trebuchet.visitor_id = i
-      @trebuchet.launch?(@feature_name).should be_false
+      Trebuchet.feature(@feature_name).launch_at?(@user, @mock_request).should be_false
     end
   end
   

--- a/spec/visitor_percent_deprecated_strategy_spec.rb
+++ b/spec/visitor_percent_deprecated_strategy_spec.rb
@@ -39,15 +39,16 @@ describe Trebuchet::Strategy::VisitorPercentDeprecated do
       # offset of some_feature is 33
       Trebuchet.aim('some_feature', feature_name, 100)
       offset = Trebuchet.feature('some_feature').strategy.offset
-      t = Trebuchet.new(User.new(0), mock_request('12345'))
-      t.launch?('some_feature').should == true
+      user = User.new(0)
+      request = mock_request('12345')
+      Trebuchet.feature('some_feature').launch_at?(user, request).should == true
       visitor_id = Trebuchet.visitor_id.call
 
       Trebuchet.aim('some_feature', feature_name, 91) # 33 + 91 includes 123 % 100
-      t.launch?('some_feature').should == true
+      Trebuchet.feature('some_feature').launch_at?(user, request).should == true
 
       Trebuchet.aim('some_feature', feature_name, 90)
-      t.launch?('some_feature').should == false
+      Trebuchet.feature('some_feature').launch_at?(user, request).should == false
     end
 
     it 'should launch' do
@@ -91,20 +92,22 @@ describe Trebuchet::Strategy::VisitorPercentDeprecated do
 
     before do
       @feature = Trebuchet.feature("liberty")
-      @trebuchet = Trebuchet.new(User.new(0), mock_request('abcdef'))
+      @user = User.new(0)
+      @request = mock_request('abcdef')
+      @trebuchet = Trebuchet.new(@user, @request)
     end
 
     it "should use from and to" do
       @feature.aim(:visitor_percent_deprecated, :from => 5, :to => 10)
       Trebuchet.feature("liberty").strategy.offset.should == 0
       Trebuchet.visitor_id = 10
-      @trebuchet.launch?("liberty").should == true
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == true
       Trebuchet.visitor_id = 5
-      @trebuchet.launch?("liberty").should == true
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == true
       Trebuchet.visitor_id = 4
-      @trebuchet.launch?("liberty").should == false
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == false
       Trebuchet.visitor_id = 11
-      @trebuchet.launch?("liberty").should == false
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == false
     end
 
     it "should use a percentage" do
@@ -112,13 +115,13 @@ describe Trebuchet::Strategy::VisitorPercentDeprecated do
       offset = @feature.strategy.offset
       offset.should == 90
       Trebuchet.visitor_id = 24 + offset
-      @trebuchet.launch?("liberty").should == true
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == true
       Trebuchet.visitor_id = 0 + offset
-      @trebuchet.launch?("liberty").should == true
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == true
       Trebuchet.visitor_id = 5 + offset
-      @trebuchet.launch?("liberty").should == true
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == true
       Trebuchet.visitor_id = 25 + offset
-      @trebuchet.launch?("liberty").should == false
+      Trebuchet.feature("liberty").launch_at?(@user, @request).should == false
     end
 
   end

--- a/spec/visitor_percent_strategy_spec.rb
+++ b/spec/visitor_percent_strategy_spec.rb
@@ -32,15 +32,17 @@ describe Trebuchet::Strategy::VisitorPercent do
 
     it 'should launch' do
       Trebuchet.aim('some_feature', :visitor_percent, 100)
-      t = Trebuchet.new(User.new(0), mock_request('12345'))
-      t.launch?('some_feature').should == true
+      user = User.new(0)
+      request = mock_request('12345')
+
+      Trebuchet.feature('some_feature').launch_at?(user, request).should == true
       visitor_id = Trebuchet.visitor_id.call
 
       Trebuchet.aim('some_feature', :visitor_percent, 91)
-      t.launch?('some_feature').should == true
+      Trebuchet.feature('some_feature').launch_at?(user, request).should == true
 
       Trebuchet.aim('some_feature', :visitor_percent, 10)
-      t.launch?('some_feature').should == false
+      Trebuchet.feature('some_feature').launch_at?(user, request).should == false
     end
   end
 


### PR DESCRIPTION
Implements a simple cache on Trebuchet#launch?.  This avoids expensive
construction and evaluation of strategies for calls on the same feature.
This also causes the result of Trebuchet#launch? to be fixed for the
lifespan of the Trebuchet instance, which seems desirable.

The Trebuchet instance is created around a user and a request, with
neither of these fields being mutable.  Strategies, including custom
strategies, are functions of (user, request), so this should be a safe
level to cache at.  In test, Trebuchet.visitor_id is global state that
influences the result of some strategies, but in actual usage,
visitor_id is defined as a function of request.

Additionally, this has the side effect of covering over caching behavior
in some backends that results in features for which no strategy has been
defined are not cached (forcing the worst case performance).

/cc @randyzhao @jtai