### PR TITLE
Handle cases where caller forgets question mark

### DIFF
--- a/lib/trebuchet.rb
+++ b/lib/trebuchet.rb
@@ -111,7 +111,10 @@ class Trebuchet
   end
 
   def launch(feature, &block)
-    if launch?(feature)
+    unless block_given?
+      # If there's no block, the caller probably meant launch?
+      return launch?(feature)
+    elsif launch?(feature)
       yield if block_given?
     end
   end


### PR DESCRIPTION
@schleyfox @randyzhao 

I've accidentally called `launch` instead of `launch?`. It's confusing because it doesn't raise an exception and always returns false.