### PR TITLE
Use before_action instead of before_filter in Rails 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.11.0 (Aug 15, 2019)
+ - add Rails 5 compatibility
+
 ## 0.10.1 (Jul 13, 2018)
  - add PerDenomination strategy
 

--- a/app/controllers/trebuchet_rails/features_controller.rb
+++ b/app/controllers/trebuchet_rails/features_controller.rb
@@ -1,8 +1,12 @@
 module TrebuchetRails
-  
+
   class FeaturesController < ApplicationController
-  
-    before_filter :control_access, :get_time_zone
+
+    if Rails::VERSION::MAJOR >= 5
+      before_action :control_access, :get_time_zone
+    else
+      before_filter :control_access, :get_time_zone
+    end
 
     layout 'trebuchet'
     helper :trebuchet

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.10.1"
+  VERSION = "0.11.0"
 
 end


### PR DESCRIPTION
I'm upgrading a Rails application which depends on this gem to Rails 5.1. The controller class method `before_filter` is [deprecated in Rails 5.0](https://github.com/rails/rails/blob/v5.0.0.beta2/actionpack/lib/abstract_controller/callbacks.rb#L190-L193), and removed in Rails 5.1 (it was just renamed to `before_action`). So this change is required for compatibility with Rails 5 applications.

I tested this by recreating this change in my local version of the gem, and verifying that it removed the following exception:
`NoMethodError: undefined method 'before_filter' for TrebuchetRails::FeaturesController:Class`

cc @Umofomia 