### PR TITLE
Optionally store Trebuchet class-level state thread-locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+cache: bundler
+sudo: false
+rvm:
+  - 1.9.3
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+
+before_install:
+  - gem install bundler -v 1.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.0 (Nov 26, 2019)
+ - Contain fiber-unsafe state of the main Trebuchet class into a state object and optionally store it as a thread/fiber local.
+
 ## 0.11.0 (Aug 15, 2019)
  - add Rails 5 compatibility
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in trebuchet.gemspec
 gemspec
+
+current_ruby = Gem::Version.new(RUBY_VERSION)
+if current_ruby < Gem::Version.new("2.2")
+  gem "rake", "< 12.3"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,3 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in trebuchet.gemspec
 gemspec
-
-gem 'rake', '~> 10.0.3'
-
-group :test do
-  gem 'mock_redis', "~> 0.6.5"
-  gem 'rspec', "~> 2.12.0"
-end

--- a/README.md
+++ b/README.md
@@ -103,3 +103,10 @@ First, set the visitor id either directly (in a before filter) or as a proc:
 
 If you're using a proc, Trebuchet passes in the request object. It expects that the proc returns an integer.
 If it returns anything else, Trebuchet will not launch.
+
+Fiber and Thread Safety
+-------------
+
+Trebuchet stores global state such as `Trebuchet.current` which is thread and fiber unsafe behavior. In order to use these
+features in a fiber or threaded environment, `Trebuchet.threadsafe_state = true` will cause Trebuchet to store these values
+in a thread-local state object instead. This is not the default for backward compatability reasons.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Setup
 
 
 Trebuchet defaults to storing data in memory, or can be used with Redis or Memcache as a data store:
-    
+
     Trebuchet.set_backend :memcached
     Trebuchet.set_backend :redis, :client => Redis.new(:host => 'example.com')
     Trebuchet.set_backend :redis_cached, :client => Redis.new(:host => 'example.com')

--- a/lib/trebuchet/state.rb
+++ b/lib/trebuchet/state.rb
@@ -1,0 +1,5 @@
+# Represents the internal, global and thread-unsafe state of Trebuchet
+Trebuchet::State = Struct.new(
+  :visitor_id, :current, :current_block,
+  :logs, :admin_view, :admin_edit, :time_zone
+)

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 
 end

--- a/spec/custom_strategy_spec.rb
+++ b/spec/custom_strategy_spec.rb
@@ -23,14 +23,14 @@ describe Trebuchet::Strategy::Custom do
     Trebuchet.new(User.new(1, :power_user)).launch?('power_feature').should be_true
     Trebuchet.new(User.new(1, :user)).launch?('power_feature').should be_false
   end
-  
+
   it "should allow an always-on strategy" do
     Trebuchet.define_strategy(:yes) { |user| true }
     Trebuchet.aim("perma-feature", :yes)
     Trebuchet.new(User.new 999).launch?("perma-feature").should be_true
     Trebuchet.new(User.new nil).launch?("perma-feature").should be_true
   end
-  
+
   it "should needs_user? based on block arity" do
     # still a good idea to nilcheck within block however
     pending "re-enable after switching to  { |options, user, request| }"

--- a/trebuchet.gemspec
+++ b/trebuchet.gemspec
@@ -19,14 +19,8 @@ Gem::Specification.new do |s|
 
   # redis and memcache are optional
   s.add_dependency 'json'
-  
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency("rspec", ["~> 2.5.0"])
-    else
-    end
-  else
-  end
+  s.add_development_dependency 'rspec', '~> 2.12.0'
+  s.add_development_dependency 'mock_redis', '~> 0.6.5'
+  s.add_development_dependency 'rake', '>= 10.0.3'
 end


### PR DESCRIPTION
Trebuchet is thread- and fiber-unsafe. The most obvious reason for this is the storage of global state such `current` in class instance variables.

This change:

1. Shifts `Trebuchet` state which is likely to change between fibers/threads or request to request into a state object.
1. Optionally allows that state to be stored thread local. This is an option and not the default for backward compatibility, as it would be trivial to demonstrate threaded code which relies on such thread-unsafe behavior.
1. Configures Travis CI
1. Cleans up the Gemfile/gemspec and removes extremely old version checks, rubygems 1.2.0 was < 2009. 

This is not meant to exhaustively correct all possible thread or fiber safety issues in Trebuchet.