### PR TITLE
Fix missing state author methods

### DIFF
--- a/lib/trebuchet/state.rb
+++ b/lib/trebuchet/state.rb
@@ -1,5 +1,6 @@
 # Represents the internal, global and thread-unsafe state of Trebuchet
 Trebuchet::State = Struct.new(
   :visitor_id, :current, :current_block,
-  :logs, :admin_view, :admin_edit, :time_zone
+  :logs, :admin_view, :admin_edit, :time_zone,
+  :author
 )

--- a/lib/trebuchet/version.rb
+++ b/lib/trebuchet/version.rb
@@ -1,5 +1,5 @@
 class Trebuchet
 
-  VERSION = "0.12.0"
+  VERSION = "0.12.1".freeze
 
 end

--- a/spec/trebuchet_spec.rb
+++ b/spec/trebuchet_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Trebuchet do
-  
+
   describe "launch?" do
-    
+
     it "should call launch_at? on feature" do
       Trebuchet::Feature.any_instance.should_receive(:launch_at?).once
       Trebuchet.new(User.new(1)).launch?('highly_experimental')
     end
-  
+
     it "should  call launch_at? on feature even if missing user" do
       Trebuchet::Feature.any_instance.should_receive(:launch_at?).once
       Trebuchet.new(nil).launch?('highly_experimental')
@@ -26,7 +26,7 @@ describe Trebuchet do
       t.launch?('waste_of_time')
     end
   end
-    
+
   describe "launch" do
     it "should execute a block" do
       times = 0
@@ -35,7 +35,7 @@ describe Trebuchet do
       (Trebuchet.new(User.new(3)).launch('highly_experimental') { times += 1 }).should be_false
       times.should == 1
     end
-    
+
     it "should not blow up if block is missing" do
       lambda do
         Trebuchet.aim('highly_experimental', :users, [1,2])
@@ -43,42 +43,42 @@ describe Trebuchet do
         Trebuchet.new(User.new(3)).launch('highly_experimental').should be_false
         Trebuchet.new(nil).launch('highly_experimental').should be_false
       end.should_not raise_error(LocalJumpError)
-      
+
     end
-    
+
   end
-  
+
   describe "logging" do
-    
+
     before(:all) do
       Trebuchet.aim('highly_experimental', :users, [1,2])
       Trebuchet.aim('disused', :disabled)
     end
-    
+
     before(:each) do
       Trebuchet.initialize_logs
     end
-    
+
     it "should log" do
       Trebuchet.logs.should == {}
       Trebuchet.new(User.new(1)).launch?('highly_experimental').should == true
       Trebuchet.logs['highly_experimental'].should == true
     end
-    
+
     it "should log false/nil" do
       Trebuchet.logs['complely_fabricated'] == nil
       Trebuchet.logs['disused'].should == nil
       Trebuchet.new(User.new(1)).launch?('disused') #.should == false
       Trebuchet.logs['disused'].should == false
     end
-    
+
     it "it should clear logs" do
       Trebuchet.new(User.new(1)).launch?('highly_experimental').should == true
       Trebuchet.logs['highly_experimental'].should == true
       Trebuchet.initialize_logs
       Trebuchet.logs.should == {}
     end
-    
+
     it "should log from multiple trebuchet instances" do
       Trebuchet.new(User.new(1)).launch?('highly_experimental') #.should == true
       Trebuchet.new(User.new(1)).launch?('disused') #.should == false
@@ -87,7 +87,7 @@ describe Trebuchet do
       Trebuchet.logs['disused'].should == false
       Trebuchet.logs['waste_of_time'].should == false
     end
-    
+
   end
 
   describe "exception handling" do
@@ -122,7 +122,7 @@ describe Trebuchet do
       Trebuchet.exception_handler = lambda { @last_arg = eval local_variables.last.to_s }
       Trebuchet.current.launch?("optimism")
       @last_arg.should == nil
-      
+
       Trebuchet.exception_handler = lambda { |e| @last_arg = eval local_variables.last.to_s  }
       Trebuchet.current.launch?("optimism")
       @last_arg.should be_a(StandardError)
@@ -156,5 +156,15 @@ describe Trebuchet do
     end
 
   end
-  
+
+  it "stores state variables" do
+    %i{author admin_view admin_edit time_zone}.each do |key|
+      begin
+        Trebuchet.public_send :"#{key}=", 1
+        expect(Trebuchet.public_send(key)).to eq 1
+      ensure
+        Trebuchet.public_send :"#{key}=", nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
`#author=` and `#author` were not exercised by the tests and were not added to `Trebuchet::State` causing existing strategies to fail.